### PR TITLE
Update border-radius for flashcard clip in Flashcards.svelte

### DIFF
--- a/src/lib/components/Flashcards.svelte
+++ b/src/lib/components/Flashcards.svelte
@@ -257,6 +257,7 @@
             inset: -2rem;
             overflow: clip;
             pointer-events: none; /* click-through because this overlaps other buttons/elements */
+            border-radius: 0.8rem;
         }
         .keyed-flashcards-clip-wrapper > .card {
             pointer-events: auto; /* reset click-through from the wrapper so the card itself is still clickable */


### PR DESCRIPTION
one line change for `border-radius: 0.8rem`